### PR TITLE
Various fixes

### DIFF
--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -1,18 +1,12 @@
 # 💫 About Frontity
 
-* [What is Frontity?](./#what-is-frontity)
-* [Why WordPress and React?](./#why-wordpress-and-react)
-* [How does Frontity work?](./#how-does-frontity-work)
-* [Frontity features](./#frontity-features)
-* [Key differences with GatsbyJS](./#key-differences-from-gatsbyjs)
-
 ## What is Frontity?
 
-Frontity is a free and open source framework. It enables you to easily build a **React-based frontend** for a [headless (or decoupled) WordPress](https://www.elegantthemes.com/blog/wordpress/headless-wordpress) site. Your WordPress site serves its data via the REST API, and the frontend that you build with Frontity consumes this data and renders it in the browser as a SPA (Single Page Application) which you can configure and style to your liking.
+Frontity is a free and open source framework. It enables you to easily build a **React-based frontend** for a [**headless (or decoupled) WordPress**](https://www.elegantthemes.com/blog/wordpress/headless-wordpress) site. Your WordPress site serves its data via the [**REST API**](https://developer.wordpress.org/rest-api/), and the frontend that you build with Frontity consumes this data and renders it in the browser as a SPA (Single Page Application) which you can configure and style to your liking.
 
-The above approach, as exemplified by Frontity, has many advantages. But in order to build a website in this way without Frontity there are a **lot of things** that developers need **to learn** and configure: _bundling_, _transpiling_, _routing_, _server rendering_, _retrieving data from WordPress_, _managing state_, or _managing css_, among many others.
+The above approach, as exemplified by Frontity, has many advantages. But in order to build a website in this way without Frontity there are a lot of things that developers need to learn and configure: _bundling_, _transpiling_, _routing_, _server rendering_, _retrieving data from WordPress_, _managing state_, or _managing css_, among many others.
 
-Next.js and Gatbsy.js are two great React frameworks that can work with WordPress in this way but none of them is exclusively focused on WordPress. Therefore, there’s still some **complex configuration** and additional tooling that the developer has to do.
+Next.js and Gatbsy.js are two great React frameworks that can work with WordPress in this way but none of them is exclusively focused on WordPress. Therefore, there’s still some complex configuration and additional tooling that the developer has to do.
 
 Frontity, on the other hand, is an opinionated framework based on React and focused on WordPress. It aims to make everything simpler, even for  developers who are not familiar with React:
 
@@ -27,13 +21,13 @@ Frontity can also be described as an alternative rendering engine for WordPress.
 
 Traditionally WordPress generates HTML using a theme based on **PHP** template files.
 
-When the [REST API](https://developer.wordpress.org/rest-api/) was merged into core in WordPress 4.7, developers were **no longer limited** to the PHP rendering engine. They could query WordPress for the stored content which WordPress then sent in JSON format. The developer could then use it wherever and however they wanted. This opened up a new world of possibilities for web developers.
+When the [**REST API**](https://developer.wordpress.org/rest-api/) was merged into core in WordPress 4.7, developers were no longer limited to the PHP rendering engine. They could query WordPress for the stored content which WordPress then sent in JSON format. The developer could then use it wherever and however they wanted. This opened up a new world of possibilities for web developers.
 
 One of those possibilities is to create frontend sites based on React. That’s where Frontity comes into play.
 
 ## **Why WordPress and React?**
 
-As at time of writing (April 2020), WordPress powers [35% of all the websites](https://w3techs.com/technologies/details/cm-wordpress) on the Internet. Its **market share** has been growing over the last few years and it shows no sign of slowing down.
+As at time of writing (April 2020), WordPress powers [35% of all the websites](https://w3techs.com/technologies/details/cm-wordpress) on the Internet. Its market share has been growing over the last few years and it shows no sign of slowing down.
 
 ![](https://w3techs.com/diagram/history_technology/cm-wordpress)
 
@@ -52,7 +46,7 @@ Frontity apps require a Node.js server to run on. This runs in tandem with the W
 * Frontity requests content from the WordPress REST-API and uses it to generate the final HTML that is displayed in the browser.
 * Frontity is also capable of generating AMP pages using the same React code and CSS.
 
-![](.gitbook/assets/frontity-architecture%20%281%29.png)
+![](../.gitbook/assets/frontity-architecture%20%281%29.png)
 
 **Why a different Node.js server?**
 
@@ -103,6 +97,6 @@ In addition:
 * There is no need to learn GraphQL or the REST API. The data is available to you using Frontity's built in State Manager.
 * Frontity can output HTML suitable for Google AMP with exactly the same React codebase.
 
-If you still have any questions about Frontity, do please join us in our [community forum](https://community.frontity.org) and feel free to ask them there. Our growing community of users and developers will be more than happy to help you out.
+If you still have any questions about Frontity, do please join us in our [**community forum**](https://community.frontity.org) and feel free to ask them there. Our growing community of users and developers will be more than happy to help you out.
 
-One of our goals is to build a **community** of people interested in WordPress and React, so we’d love to meet you and learn about the project (or projects) that you're building with Frontity.
+One of our goals is to build a community of people interested in WordPress and React, so we’d love to meet you and learn about the project (or projects) that you're building with Frontity.


### PR DESCRIPTION
Removed menu at head of page - gitbook provides a sidebar menu with links to main headings in the document.
Removed distracting bold text.
Fixed broken link to image.