### PR TITLE
Change query to an object in wp-source example

### DIFF
--- a/docs/api-reference-1/wordpress-source.md
+++ b/docs/api-reference-1/wordpress-source.md
@@ -242,7 +242,9 @@ will return something like
   taxonomy: "category",
   id: 7,
   link: "/category/nature/page/3?s=park",
-  query: "",
+  query: {
+    s: "park"
+  },
 
   // Booleans that identify the type of link.
   isArchive: true,


### PR DESCRIPTION
It was a string and that is wrong. It's an object.