### PR TITLE
Correct the docs for `libraries.api.get/set/init`

### DIFF
--- a/docs/api-reference-1/wordpress-source.md
+++ b/docs/api-reference-1/wordpress-source.md
@@ -342,9 +342,9 @@ source.author[4]
 
 ### Libraries
 
-#### `api.set({ api, isWpCom })`
+#### `api.init({ api, isWpCom })`
 
-Request entity to the WordPress REST API.
+Set the URL to the WordPress REST API.
 
 **arguments**
 
@@ -371,7 +371,7 @@ api.init({
 
 #### `api.get({ endpoint, params, api?, isWpCom? })`
 
-Request entity to the WordPress REST API.
+Request entity from the WordPress REST API.
 
 **arguments**
 


### PR DESCRIPTION
This fixes #49.

Maybe we can also expand on the descriptions for both `api.get()` and `api.init()`, but I will leave that up to you to decide.

