### PR TITLE
fix link for "Deploy Frontity using now (Vercel)"

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ You will need to have one or two servers. At the very least, you will need a PHP
 1. PHP Server: In this case, we recommend to **continue using your actual server** for WordPress site or select your preferred hosting service such as [Siteground](https://www.siteground.com), [Raiola Networks](https://raiolanetworks.es/), [Webempresa](https://www.webempresa.com/) or any other.
 2. Node Server: In case you need this one, we would recommend to choose a [**serverless**](https://about.gitlab.com/topics/serverless/) **solution** as it will make it cheap, easy and infinitely scalable. We would select [Vercel Now](https://vercel.com/docs/now-cli#commands/overview) because it is really easy to set up and includes a CDN too, but there are other good options like [AWS Lambda](https://aws.amazon.com/lambda), [Netlify](https://www.netlify.com/) or [Google Functions](https://cloud.google.com/functions/).
 
-You can check out our documentation [how to deploy Frontity using `now` \(Vercel\)](https://github.com/frontity/gitbook-docs/tree/a6a79476ae299fdebf52cf13ddeaca9ede179f24/deployment/deploy-using-now-vercel.md).
+You can check out our documentation [how to deploy Frontity using `now` \(Vercel\)](https://docs.frontity.org/deployment/deploy-using-now-vercel).
 
 {% hint style="info" %}
 If you want to know more about what Serverless means you should check out [this article](https://hackernoon.com/what-is-serverless-architecture-what-are-its-pros-and-cons-cc4b804022e9).
@@ -68,7 +68,7 @@ If you use Vercel Now, the serverless option we recommend, you won't have to wor
 Although there are some other ways to have a have a Frontity site running in production and the final solution may be different depending on the website, for the majority of sites we recommend:
 
 1. Having the WordPress dashboard in a PHP server and Frontity in a Node Server.
-2. **Keep the actual PHP server** you are using for WordPress for your backend \(or select a new one\), and [**deploy Frontity using `now` \(Vercel\)**](https://github.com/frontity/gitbook-docs/tree/a6a79476ae299fdebf52cf13ddeaca9ede179f24/deployment/deploy-using-now-vercel.md), a serverless, cheap, infinitely scalable and easy to set up solution.
+2. **Keep the actual PHP server** you are using for WordPress for your backend \(or select a new one\), and [**deploy Frontity using `now` \(Vercel\)**](https://docs.frontity.org/deployment/deploy-using-now-vercel), a serverless, cheap, infinitely scalable and easy to set up solution.
 3. Point your main domain www.myblog.com to Frontity and use a subdomain \(wp.myblog.com\) for WordPress.
 4. If you have selected Now as your Node server solution, you won't need to worry about this, as it offers a CDN and the stale-while-revalidate technique \(or [Serverless Pre-Rendering](https://vercel.com/blog/serverless-pre-rendering) as they name it\). If you selected another solution, we would recommend you to use [KeyCDN](https://www.keycdn.com) or [StackPath](https://www.stackpath.com/) as additional services.
 


### PR DESCRIPTION
Changed link for "Deploy Frontity using now (Vercel)" from github to docs.